### PR TITLE
feat: 분석기 DTO 작업, Python에서도 변경된 DTO에 맞춰 작업 / 분석 결과에서 generic type 표시, 메서드 선언 순서대로 표시

### DIFF
--- a/class-analyzer/build.gradle.kts
+++ b/class-analyzer/build.gradle.kts
@@ -23,9 +23,13 @@ dependencies {
     * */
     implementation("org.slf4j:slf4j-simple:2.0.16") // (cf.) implementation("org.slf4j:slf4j-api:2.0.16")는 spoon-core에 포함됨
 
+    // test - JUnit5
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
-    
+    // test - AssertJ Core
+    testImplementation("org.assertj:assertj-core:3.26.3")
+
+
     // Kotlin 관련
     implementation(kotlin("stdlib-jdk8"))
 }

--- a/class-analyzer/build.gradle.kts
+++ b/class-analyzer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "io"
-version = "0.1-SNAPSHOT"
+version = "0.2-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/class-analyzer/build.gradle.kts
+++ b/class-analyzer/build.gradle.kts
@@ -39,7 +39,8 @@ tasks {
         useJUnitPlatform()
     }
 
-    register<Jar>("buildFatJar") {
+    register<Jar>("fatJar") {
+        group = "build" // 참고 - https://kwonnam.pe.kr/wiki/gradle/task (Gradle Task)
         duplicatesStrategy = DuplicatesStrategy.WARN // 파일명 중복 시 경고
         from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) }) {
             exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")

--- a/class-analyzer/src/main/java/io/classanalyzer/ClassAnalyzerController.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/ClassAnalyzerController.kt
@@ -1,42 +1,24 @@
 package io.classanalyzer
 
-import org.slf4j.Logger
+import io.classanalyzer.dto.TypeSimpleInfo
+import io.classanalyzer.service.TypeSimpleInfoProvider
 import org.slf4j.LoggerFactory
 import spoon.JarLauncher
-import spoon.reflect.CtModel
-import spoon.reflect.declaration.CtType
 import java.io.File
 import java.io.IOException
 
 class ClassAnalyzerController {
 
-    private val logger: Logger = LoggerFactory.getLogger(ClassAnalyzerController::class.java)
+    private val logger = LoggerFactory.getLogger(ClassAnalyzerController::class.java)
     private val decompiledCodeDirectory = File("temp\\decompiled")
+    private val typeSimpleInfoProvider = TypeSimpleInfoProvider()
 
-    fun analyze(targetJarPath: String): CtModel {
+    fun analyze(targetJarPath: String): List<TypeSimpleInfo> {
         // 기초적인 사용법 https://spoon.gforge.inria.fr/launcher.html
         // API docs https://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/
         val jarLauncher = JarLauncher(targetJarPath, decompiledCodeDirectory.path)
         jarLauncher.buildModel()
-        val model = jarLauncher.model
-        /*
-        for (targetType in model.allTypes) {
-            targetType.declaredFields.forEach {
-                val fieldDeclaration = it.fieldDeclaration
-                println(fieldDeclaration.getSimpleName())
-                println(fieldDeclaration.getVisibility())
-                println(fieldDeclaration.getType().simpleName)
-            }
-
-            targetType.methods.forEach {
-                println(it.getSimpleName())
-                println(it.getVisibility())
-                println(it.getParameters().map { it.getType().getSimpleName() })
-                println(it.getType())
-            }
-        }
-*/
-        return model
+        return typeSimpleInfoProvider.provideTypeSimpleInfoList(jarLauncher.model)
     }
 
     fun cleanDecompiled() {
@@ -49,9 +31,4 @@ class ClassAnalyzerController {
             throw RuntimeException(e)
         }
     }
-    /*
-    fun test(test1: String, test2: List<Map<String, String>>) {
-        return
-    }
-    */
 }

--- a/class-analyzer/src/main/java/io/classanalyzer/dto/FieldSimpleInfo.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/dto/FieldSimpleInfo.kt
@@ -1,0 +1,7 @@
+package io.classanalyzer.dto
+
+data class FieldSimpleInfo(
+    val simpleName: String,
+    val visibility: String,
+    val type: String,
+)

--- a/class-analyzer/src/main/java/io/classanalyzer/dto/MethodSimpleInfo.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/dto/MethodSimpleInfo.kt
@@ -1,0 +1,8 @@
+package io.classanalyzer.dto
+
+data class MethodSimpleInfo(
+    val simpleName: String,
+    val visibility: String,
+    val parameterTypeList: List<String>,
+    val returnType: String,
+)

--- a/class-analyzer/src/main/java/io/classanalyzer/dto/TypeSimpleInfo.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/dto/TypeSimpleInfo.kt
@@ -1,0 +1,7 @@
+package io.classanalyzer.dto
+
+data class TypeSimpleInfo(
+    val simpleName: String,
+    val fields: List<FieldSimpleInfo>,
+    val methods: List<MethodSimpleInfo>,
+)

--- a/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
@@ -31,14 +31,14 @@ class TypeSimpleInfoProvider {
     private fun refineToFieldSimpleInfo(ctField: CtField<*>) =
         FieldSimpleInfo(
             simpleName = ctField.simpleName,
-            visibility = ctField.visibility.name,
+            visibility = ctField.visibility.toString(),
             type = flattenCtTypeReference(ctField.type),
         )
 
     private fun refineToMethodSimpleInfo(ctMethod: CtMethod<*>) =
         MethodSimpleInfo(
             simpleName = ctMethod.simpleName,
-            visibility = ctMethod.visibility.name,
+            visibility = ctMethod.visibility.toString(),
             parameterTypeList = ctMethod.parameters.map { flattenCtTypeReference(it.type) },
             returnType = flattenCtTypeReference(ctMethod.type),
         )

--- a/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
@@ -17,7 +17,9 @@ class TypeSimpleInfoProvider {
 
     private fun <T> refineToTypeSimpleInfo(ctType: CtType<T>): TypeSimpleInfo {
         val refinedFields = ctType.fields.map { refineToFieldSimpleInfo(it) }
-        val refinedMethods = ctType.methods.map { refineToMethodSimpleInfo(it) }
+        val refinedMethods = ctType.methods
+            .sortedWith(Comparator.comparing { it.position.line }) // 메서드 선언 순서대로 정렬
+            .map { refineToMethodSimpleInfo(it) }
 
         return TypeSimpleInfo(
             simpleName = ctType.simpleName,

--- a/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
@@ -15,7 +15,7 @@ class TypeSimpleInfoProvider {
         return ctModel.allTypes.map { refineToTypeSimpleInfo(it) }
     }
 
-    private fun <T> refineToTypeSimpleInfo(ctType: CtType<T>): TypeSimpleInfo {
+    private fun refineToTypeSimpleInfo(ctType: CtType<*>): TypeSimpleInfo {
         val refinedFields = ctType.fields.map { refineToFieldSimpleInfo(it) }
         val refinedMethods = ctType.methods
             .sortedWith(Comparator.comparing { it.position.line }) // 메서드 선언 순서대로 정렬
@@ -28,14 +28,14 @@ class TypeSimpleInfoProvider {
         )
     }
 
-    private fun <T> refineToFieldSimpleInfo(ctField: CtField<T>) =
+    private fun refineToFieldSimpleInfo(ctField: CtField<*>) =
         FieldSimpleInfo(
             simpleName = ctField.simpleName,
             visibility = ctField.visibility.name,
             type = flattenCtTypeReference(ctField.type),
         )
 
-    private fun <T> refineToMethodSimpleInfo(ctMethod: CtMethod<T>) =
+    private fun refineToMethodSimpleInfo(ctMethod: CtMethod<*>) =
         MethodSimpleInfo(
             simpleName = ctMethod.simpleName,
             visibility = ctMethod.visibility.name,

--- a/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
@@ -1,0 +1,35 @@
+package io.classanalyzer.service
+
+import io.classanalyzer.dto.FieldSimpleInfo
+import io.classanalyzer.dto.MethodSimpleInfo
+import io.classanalyzer.dto.TypeSimpleInfo
+import spoon.reflect.CtModel
+import spoon.reflect.declaration.CtField
+import spoon.reflect.declaration.CtMethod
+import spoon.reflect.declaration.CtType
+
+class TypeSimpleInfoProvider {
+
+    fun provideTypeSimpleInfoList(ctModel: CtModel): List<TypeSimpleInfo> {
+        return ctModel.allTypes.map { refineToTypeSimpleInfo(it) }
+    }
+
+    private fun <T> refineToTypeSimpleInfo(ctType: CtType<T>): TypeSimpleInfo {
+        val fields = ctType.fields.map { refineToFieldSimpleInfo(it) }
+        val methods = ctType.methods.map { refineToMethodSimpleInfo(it) }
+
+        return TypeSimpleInfo(
+            simpleName = ctType.simpleName,
+            fields = fields,
+            methods = methods,
+        )
+    }
+
+    private fun <T> refineToFieldSimpleInfo(ctField: CtField<T>): FieldSimpleInfo {
+        return FieldSimpleInfo("", "", "")
+    }
+
+    private fun <T> refineToMethodSimpleInfo(ctMethod: CtMethod<T>): MethodSimpleInfo {
+        return MethodSimpleInfo("", "", listOf(""), "")
+    }
+}

--- a/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
+++ b/class-analyzer/src/main/java/io/classanalyzer/service/TypeSimpleInfoProvider.kt
@@ -7,6 +7,7 @@ import spoon.reflect.CtModel
 import spoon.reflect.declaration.CtField
 import spoon.reflect.declaration.CtMethod
 import spoon.reflect.declaration.CtType
+import spoon.reflect.reference.CtTypeReference
 
 class TypeSimpleInfoProvider {
 
@@ -15,21 +16,42 @@ class TypeSimpleInfoProvider {
     }
 
     private fun <T> refineToTypeSimpleInfo(ctType: CtType<T>): TypeSimpleInfo {
-        val fields = ctType.fields.map { refineToFieldSimpleInfo(it) }
-        val methods = ctType.methods.map { refineToMethodSimpleInfo(it) }
+        val refinedFields = ctType.fields.map { refineToFieldSimpleInfo(it) }
+        val refinedMethods = ctType.methods.map { refineToMethodSimpleInfo(it) }
 
         return TypeSimpleInfo(
             simpleName = ctType.simpleName,
-            fields = fields,
-            methods = methods,
+            fields = refinedFields,
+            methods = refinedMethods,
         )
     }
 
-    private fun <T> refineToFieldSimpleInfo(ctField: CtField<T>): FieldSimpleInfo {
-        return FieldSimpleInfo("", "", "")
-    }
+    private fun <T> refineToFieldSimpleInfo(ctField: CtField<T>) =
+        FieldSimpleInfo(
+            simpleName = ctField.simpleName,
+            visibility = ctField.visibility.name,
+            type = flattenCtTypeReference(ctField.type),
+        )
 
-    private fun <T> refineToMethodSimpleInfo(ctMethod: CtMethod<T>): MethodSimpleInfo {
-        return MethodSimpleInfo("", "", listOf(""), "")
+    private fun <T> refineToMethodSimpleInfo(ctMethod: CtMethod<T>) =
+        MethodSimpleInfo(
+            simpleName = ctMethod.simpleName,
+            visibility = ctMethod.visibility.name,
+            parameterTypeList = ctMethod.parameters.map { flattenCtTypeReference(it.type) },
+            returnType = flattenCtTypeReference(ctMethod.type),
+        )
+
+    companion object GenericTypeFlattener {
+        fun <T> flattenCtTypeReference(ctTypeReference: CtTypeReference<T>): String {
+            val genericTypeList = ctTypeReference.actualTypeArguments
+            // (cf.) generic type의 CtTypeReference에 대해서도 재귀적으로 평탄화시킴
+            val flattenedGenericType = genericTypeList.joinToString(", ") { flattenCtTypeReference(it) }
+
+            return if (genericTypeList.isNotEmpty()) {
+                "${ctTypeReference.simpleName}<$flattenedGenericType>"
+            } else {
+                ctTypeReference.simpleName
+            }
+        }
     }
 }

--- a/class-analyzer/src/test/java/io/classanalyzer/service/TypeSimpleInfoMakerTest.kt
+++ b/class-analyzer/src/test/java/io/classanalyzer/service/TypeSimpleInfoMakerTest.kt
@@ -11,30 +11,68 @@ import java.io.FileWriter
 class TypeSimpleInfoMakerTest {
 
     private val typeSimpleInfoProvider = TypeSimpleInfoProvider()
-    private val targetClassText = """
-        class ClassForTest {
+    private val targetClassTextWithGenericType = """
+        class ClassWithGenericType {
             public List<String> fieldTest = null;
             public Set<Map<String, String>> methodTest(String[] arg1, Map<Long, String> arg2) {
                 return null;
             }
         }
     """.trimIndent()
-    private val targetClassCtModel: CtModel
+    private val ctModelWithGenericType: CtModel
+
+    private val targetClassTextWithManyMethods = """
+        class ClassWithGenericType {
+            public void firstMethod() {
+                return null;
+            }
+            
+            public void secondMethod() {
+                return null;
+            }
+            
+            public void thirdMethod() {
+                return null;
+            }
+            
+            public void fourthMethod() {
+                return null;
+            }
+            
+            public void fifthMethod() {
+                return null;
+            }
+        }
+    """.trimIndent()
+    private val ctModelWithManyMethods: CtModel
 
     init {
-        val tempFile = File.createTempFile("ClassForTest", ".java")
-        FileWriter(tempFile).use { writer -> writer.write(targetClassText) } // (cf.) use()는 let()과 비슷한데, Closeable에 대해 호출하는 함수
+        val tempFile1 = File.createTempFile("ClassWithGenericType", ".java")
+        FileWriter(tempFile1).use { writer -> writer.write(targetClassTextWithGenericType) } // (cf.) use()는 let()과 비슷한데, Closeable에 대해 호출하는 함수
+        ctModelWithGenericType = Launcher().also { it.addInputResource(tempFile1.absolutePath) }.buildModel()
 
-        targetClassCtModel = Launcher().also { it.addInputResource(tempFile.absolutePath) }.buildModel()
+        val tempFile2 = File.createTempFile("ClassWithManyMethods", ".java")
+        FileWriter(tempFile2).use { writer -> writer.write(targetClassTextWithManyMethods) }
+        ctModelWithManyMethods = Launcher().also { it.addInputResource(tempFile2.absolutePath) }.buildModel()
     }
 
     @Test
     fun testProvideTypeSimpleInfoList() {
-        val typeSimpleInformation = typeSimpleInfoProvider.provideTypeSimpleInfoList(targetClassCtModel)[0]
+        val typeSimpleInformation = typeSimpleInfoProvider.provideTypeSimpleInfoList(ctModelWithGenericType)[0]
 
-        assertThat(typeSimpleInformation.simpleName).isEqualTo("ClassForTest")
+        assertThat(typeSimpleInformation.simpleName).isEqualTo("ClassWithGenericType")
         assertThat(typeSimpleInformation.fields[0].type).isEqualTo("List<String>")
         assertThat(typeSimpleInformation.methods[0].parameterTypeList).isEqualTo(listOf("String[]", "Map<Long, String>"))
         assertThat(typeSimpleInformation.methods[0].returnType).isEqualTo("Set<Map<String, String>>")
+    }
+
+    @Test
+    fun testClassWithManyMethods() {
+        val typeSimpleInformation = typeSimpleInfoProvider.provideTypeSimpleInfoList(ctModelWithManyMethods)[0]
+        assertThat(typeSimpleInformation.methods[0].simpleName).isEqualTo("firstMethod")
+        assertThat(typeSimpleInformation.methods[1].simpleName).isEqualTo("secondMethod")
+        assertThat(typeSimpleInformation.methods[2].simpleName).isEqualTo("thirdMethod")
+        assertThat(typeSimpleInformation.methods[3].simpleName).isEqualTo("fourthMethod")
+        assertThat(typeSimpleInformation.methods[4].simpleName).isEqualTo("fifthMethod")
     }
 }

--- a/class-analyzer/src/test/java/io/classanalyzer/service/TypeSimpleInfoMakerTest.kt
+++ b/class-analyzer/src/test/java/io/classanalyzer/service/TypeSimpleInfoMakerTest.kt
@@ -14,7 +14,7 @@ class TypeSimpleInfoMakerTest {
     private val targetClassText = """
         class ClassForTest {
             public List<String> fieldTest = null;
-            public Set<Map<String, String>> methodTest {
+            public Set<Map<String, String>> methodTest(String[] arg1, Map<Long, String> arg2) {
                 return null;
             }
         }

--- a/class-analyzer/src/test/java/io/classanalyzer/service/TypeSimpleInfoMakerTest.kt
+++ b/class-analyzer/src/test/java/io/classanalyzer/service/TypeSimpleInfoMakerTest.kt
@@ -34,6 +34,7 @@ class TypeSimpleInfoMakerTest {
 
         assertThat(typeSimpleInformation.simpleName).isEqualTo("ClassForTest")
         assertThat(typeSimpleInformation.fields[0].type).isEqualTo("List<String>")
+        assertThat(typeSimpleInformation.methods[0].parameterTypeList).isEqualTo(listOf("String[]", "Map<Long, String>"))
         assertThat(typeSimpleInformation.methods[0].returnType).isEqualTo("Set<Map<String, String>>")
     }
 }

--- a/class-analyzer/src/test/java/io/classanalyzer/service/TypeSimpleInfoMakerTest.kt
+++ b/class-analyzer/src/test/java/io/classanalyzer/service/TypeSimpleInfoMakerTest.kt
@@ -1,0 +1,39 @@
+package io.classanalyzer.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import spoon.Launcher
+import spoon.reflect.CtModel
+import java.io.File
+import java.io.FileWriter
+
+
+class TypeSimpleInfoMakerTest {
+
+    private val typeSimpleInfoProvider = TypeSimpleInfoProvider()
+    private val targetClassText = """
+        class ClassForTest {
+            public List<String> fieldTest = null;
+            public Set<Map<String, String>> methodTest {
+                return null;
+            }
+        }
+    """.trimIndent()
+    private val targetClassCtModel: CtModel
+
+    init {
+        val tempFile = File.createTempFile("ClassForTest", ".java")
+        FileWriter(tempFile).use { writer -> writer.write(targetClassText) } // (cf.) use()는 let()과 비슷한데, Closeable에 대해 호출하는 함수
+
+        targetClassCtModel = Launcher().also { it.addInputResource(tempFile.absolutePath) }.buildModel()
+    }
+
+    @Test
+    fun testProvideTypeSimpleInfoList() {
+        val typeSimpleInformation = typeSimpleInfoProvider.provideTypeSimpleInfoList(targetClassCtModel)[0]
+
+        assertThat(typeSimpleInformation.simpleName).isEqualTo("ClassForTest")
+        assertThat(typeSimpleInformation.fields[0].type).isEqualTo("List<String>")
+        assertThat(typeSimpleInformation.methods[0].returnType).isEqualTo("Set<Map<String, String>>")
+    }
+}

--- a/python-application/src/service/analyzer_adapter.py
+++ b/python-application/src/service/analyzer_adapter.py
@@ -10,9 +10,9 @@ class AnalyzerAdapter:
     def analyze(self, target_jar_path: str):
         class_analyzer_connector = self.__class_analyzer_connector
 
-        analyzed_model = class_analyzer_connector.analyze(target_jar_path)
+        type_simple_info_list = class_analyzer_connector.analyze(target_jar_path)
 
-        table_writer = ClassDefinitionHwpTableWriter(HwpConnector(), analyzed_model)
+        table_writer = ClassDefinitionHwpTableWriter(HwpConnector(), type_simple_info_list)
         table_writer.writeClassDefinitionTables()
 
         class_analyzer_connector.cleanDecompiled()

--- a/python-application/src/service/class_analyzer_connector.py
+++ b/python-application/src/service/class_analyzer_connector.py
@@ -21,14 +21,14 @@ class ClassAnalyzerConnector(metaclass=ClassAnalyzerConectorMeta):
     def __init__(self) -> None:
         jpype.startJVM(
             jvmpath=jpype.getDefaultJVMPath(),
-            classpath="analyzer/class-analyzer-0.1-SNAPSHOT.jar",
+            classpath="analyzer/class-analyzer-0.2-SNAPSHOT.jar",
         )
         ClassAnalyzerController = jpype.JClass(
             "io.classanalyzer.ClassAnalyzerController"
         )
         self.__classAnalyzerController = ClassAnalyzerController()
 
-    # 대상 jar 파일 분석 후 CtModel 반환
+    # 대상 jar 파일 분석 후 List<TypeSimpleInfo> 반환
     def analyze(self, target_jar_path):
         return self.__classAnalyzerController.analyze(target_jar_path)
 

--- a/python-application/src/service/table_writer.py
+++ b/python-application/src/service/table_writer.py
@@ -4,17 +4,17 @@ from service.table_initializer import HwpTableInitializer
 
 class ClassDefinitionHwpTableWriter:
 
-    def __init__(self, hwp_connector: HwpConnector, analyzed_model):
+    def __init__(self, hwp_connector: HwpConnector, type_simple_info_list):
         self.__hwp = hwp_connector.hwp
         self.__table_initializer = HwpTableInitializer(hwp_connector)
-        self.__analyzed_model = analyzed_model
+        self.__type_simple_info_list = type_simple_info_list
 
     def writeClassDefinitionTables(self):
-        for target_type in self.__analyzed_model.getAllTypes():
-            self.__writeEachTable(target_type)
+        for type_simple_info in self.__type_simple_info_list:
+            self.__writeEachTable(type_simple_info)
             self.__addNewLineToDocumentEnd()
 
-    def __writeEachTable(self, target_type):
+    def __writeEachTable(self, type_simple_info):
         self.__table_initializer.InitializeFormTable()
 
         hwp = self.__hwp  # 사용 편의를 위한 지역변수 선언
@@ -27,8 +27,8 @@ class ClassDefinitionHwpTableWriter:
         hwp.Run("TableLowerCell")
         hwp.Run("Cancel")
 
-        fields = target_type.getDeclaredFields()
-        if field.size() > 0:
+        fields = type_simple_info.getFields()
+        if fields.size() > 0:
             # fields 사이즈 - 1만큼 행 추가
             hwp.HAction.GetDefault("TableInsertRowColumn", hwp.HParameterSet.HTableInsertLine.HSet)
             hwp.HParameterSet.HTableInsertLine.Side = 3
@@ -37,12 +37,11 @@ class ClassDefinitionHwpTableWriter:
 
             # fields 순회하며 속성명, 가시성, 타입, 기본값(N/A) 순으로 작성
             for index, field in enumerate(fields):
-                field_declaration = field.getFieldDeclaration()
-                self.__writeCellText(str(field_declaration.getSimpleName()))
+                self.__writeCellText(str(field.getSimpleName()))
                 hwp.Run("MoveRight")
-                self.__writeCellText(str(field_declaration.getVisibility()))
+                self.__writeCellText(str(field.getVisibility()))
                 hwp.Run("MoveRight")
-                self.__writeCellText(str(field_declaration.getType().getSimpleName()))
+                self.__writeCellText(str(field.getType()))
                 hwp.Run("MoveRight")
                 self.__writeCellText("N/A")
                 if index != (fields.size() - 1):
@@ -57,7 +56,7 @@ class ClassDefinitionHwpTableWriter:
         hwp.Run("TableColPageDown")
         hwp.Run("Cancel")
 
-        methods = target_type.getMethods()
+        methods = type_simple_info.getMethods()
         if methods.size() > 0:
             # methods 사이즈 - 1만큼 행 추가
             hwp.HAction.GetDefault("TableInsertRowColumn", hwp.HParameterSet.HTableInsertLine.HSet)
@@ -71,9 +70,9 @@ class ClassDefinitionHwpTableWriter:
                 hwp.Run("MoveRight")
                 self.__writeCellText(str(method.getVisibility()))
                 hwp.Run("MoveRight")
-                self.__writeMethodParameters(method.getParameters())
+                self.__writeMethodParameters(method.getParameterTypeList())
                 hwp.Run("MoveRight")
-                self.__writeCellText(str(method.getType().getSimpleName()))
+                self.__writeCellText(str(method.getReturnType()))
                 if index != (methods.size() - 1):
                     hwp.Run("TableCellBlock")
                     hwp.Run("TableColBegin")
@@ -85,7 +84,7 @@ class ClassDefinitionHwpTableWriter:
         hwp.Run("TableColEnd")
         hwp.Run("TableColPageUp")
         hwp.Run("Cancel")
-        self.__writeCellText(str(target_type.getSimpleName()))
+        self.__writeCellText(str(type_simple_info.getSimpleName()))
 
     def __addNewLineToDocumentEnd(self):
         hwp = self.__hwp  # 사용 편의를 위한 지역변수 선언
@@ -99,11 +98,11 @@ class ClassDefinitionHwpTableWriter:
         hwp.HParameterSet.HInsertText.Text = text
         hwp.HAction.Execute("InsertText", hwp.HParameterSet.HInsertText.HSet)
 
-    def __writeMethodParameters(self, parameter_list):
-        if parameter_list.size() == 0:
+    def __writeMethodParameters(self, parameter_type_list):
+        if parameter_type_list.size() == 0:
             self.__writeCellText("N/A")
 
-        for index, parameter in enumerate(parameter_list):
-            self.__writeCellText(str(parameter.getType().getSimpleName()))
-            if index != (parameter_list.size() - 1):
+        for index, parameter_type in enumerate(parameter_type_list):
+            self.__writeCellText(str(parameter_type))
+            if index != (parameter_type_list.size() - 1):
                 self.__writeCellText(",\r\n") # 한글에서는 \n으로는 \r\n으로 줄바꿈


### PR DESCRIPTION
## 개요
분석기 DTO 작업, Python에서도 변경된 DTO에 맞춰 작업
분석 결과에서 generic type 표시, 메서드 선언 순서대로 표시

## 작업 사항
- 분석기 DTO 작업
  - Spoon의 CtModel, CtType 등 복잡한 모델을 사용하지 않고
  - 분석기 쪽에서 String으로 구성된 간단한 DTO로 변환
    - type 정보에서 generics도 단순 String으로 평탄화
- Python에서도 위 변경된 DTO에 따라 로직 변경
- 분석 결과에서의 변경 사항
  - 분석 결과에서 generic type 표시
    - 단순 String으로 평탄화하여 표시
  - 메서드 선언 순서대로 표시
